### PR TITLE
修复file.type传值问题

### DIFF
--- a/src/ufile.js
+++ b/src/ufile.js
@@ -366,7 +366,7 @@ UCloudUFile.prototype.sliceUpload = function(options, success, error, progress) 
 
             var start = currentChunk * that.sliceSize;
             var end = start + that.sliceSize >= file.size ? file.size : start + that.sliceSize;
-            var currentFile = that.slice.call(file, start, end);
+            var currentFile = that.slice.call(file, start, end, file.type);
             currentFile.name = file.name;
 
             // 上传各分片


### PR DESCRIPTION
file.type没有传值成功
导致分片上传的请求头设置content-type为空字符串